### PR TITLE
Update condition to remove local products for English

### DIFF
--- a/content.js
+++ b/content.js
@@ -12,7 +12,7 @@ observer.observe(document.body, { childList: true, subtree: true });
 
 function removeLocalProducts() {
     document.querySelectorAll('span').forEach(span => {
-        if (span.textContent.trim() === 'Yerel') {
+        if (span.textContent.trim() === 'Yerel' || span.textContent.trim() === 'Local') {
             const productCard = span.closest('div[role="group"]');
             if (productCard) {
                 const topContainer = productCard.parentElement?.parentElement;


### PR DESCRIPTION
If temu language is English, it's not working since the condition only check Turkish word "Yerel". With this change it could also remove local warehouse products.