### PR TITLE
fix: restrict content script to temu.com and redesign popup UI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>"
+        "*://*.temu.com/*"
       ],
       "js": [
         "content.js"

--- a/popup.html
+++ b/popup.html
@@ -4,11 +4,147 @@
 <head>
   <meta charset="UTF-8">
   <title>Remove Local</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      width: 280px;
+      padding: 20px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e0;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+
+    .header svg {
+      flex-shrink: 0;
+    }
+
+    .header h1 {
+      font-size: 15px;
+      font-weight: 600;
+      color: #ffffff;
+      line-height: 1.3;
+    }
+
+    .toggle-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: #16213e;
+      border-radius: 10px;
+      padding: 12px 14px;
+      margin-bottom: 12px;
+    }
+
+    .toggle-label {
+      font-size: 13px;
+      color: #b0b0b0;
+    }
+
+    .toggle-label .status {
+      font-weight: 600;
+      color: #4ecca3;
+      transition: color 0.2s;
+    }
+
+    .toggle-label .status.off {
+      color: #e74c3c;
+    }
+
+    .switch {
+      position: relative;
+      width: 44px;
+      height: 24px;
+      flex-shrink: 0;
+    }
+
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      inset: 0;
+      background: #3a3a5c;
+      border-radius: 24px;
+      transition: background 0.25s;
+    }
+
+    .slider::before {
+      content: '';
+      position: absolute;
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background: #ffffff;
+      border-radius: 50%;
+      transition: transform 0.25s;
+    }
+
+    .switch input:checked + .slider {
+      background: #4ecca3;
+    }
+
+    .switch input:checked + .slider::before {
+      transform: translateX(20px);
+    }
+
+    .footer {
+      text-align: center;
+      font-size: 11px;
+      color: #555;
+    }
+
+    .footer a {
+      color: #4ecca3;
+      text-decoration: none;
+    }
+
+    .footer a:hover {
+      text-decoration: underline;
+    }
+  </style>
 </head>
 
 <body>
-  <h1>Yerel öğeleri gizle</h1>
-  <button id="toggleBtn">Yükleniyor...</button>
+  <div class="header">
+    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none"
+      stroke="#4ecca3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 6h18l-1.5 9h-15z" />
+      <circle cx="9" cy="20" r="1" />
+      <circle cx="17" cy="20" r="1" />
+      <line x1="2" y1="2" x2="22" y2="22" stroke="#e74c3c" stroke-width="2.5" />
+    </svg>
+    <h1>Yerel Ürünleri Gizle</h1>
+  </div>
+
+  <div class="toggle-row">
+    <span class="toggle-label">Filtre: <span id="statusText" class="status">...</span></span>
+    <label class="switch">
+      <input type="checkbox" id="toggleCheck">
+      <span class="slider"></span>
+    </label>
+  </div>
+
+  <div class="footer">
+    <a href="https://github.com/iltekin/remove-local-temu" target="_blank">GitHub</a>
+  </div>
+
   <script src="popup.js"></script>
 </body>
 

--- a/popup.js
+++ b/popup.js
@@ -1,52 +1,49 @@
-const toggleBtn = document.getElementById('toggleBtn');
+const toggleCheck = document.getElementById("toggleCheck");
+const statusText = document.getElementById("statusText");
 
-// Durumu yükle
 chrome.storage.sync.get({ enabled: true }, (data) => {
-    updateButton(data.enabled);
+  updateUI(data.enabled);
 });
 
-// Buton güncelleme
-function updateButton(enabled) {
-    toggleBtn.textContent = enabled ? 'Yerel Ürünleri Gizle: Açık' : 'Yerel Ürünleri Gizle: Kapalı';
+function updateUI(enabled) {
+  toggleCheck.checked = enabled;
+  statusText.textContent = enabled ? "Aktif" : "Pasif";
+  statusText.classList.toggle("off", !enabled);
 }
 
-// Toggle yap
-toggleBtn.addEventListener('click', () => {
-    chrome.storage.sync.get({ enabled: true }, (data) => {
-        const newState = !data.enabled;
-        chrome.storage.sync.set({ enabled: newState }, () => {
-            updateButton(newState);
-            // Aktif sekmeye content script çalıştır
-            chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-                chrome.scripting.executeScript({
-                    target: { tabId: tabs[0].id },
-                    func: toggleProducts,
-                    args: [newState]
-                });
-            });
-        });
+toggleCheck.addEventListener("change", () => {
+  const newState = toggleCheck.checked;
+  chrome.storage.sync.set({ enabled: newState }, () => {
+    updateUI(newState);
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      chrome.scripting.executeScript({
+        target: { tabId: tabs[0].id },
+        func: toggleProducts,
+        args: [newState],
+      });
     });
+  });
 });
 
-// İçerik script için fonksiyon
 function toggleProducts(enabled) {
-    if (!enabled) {
-        // Sayfayı geri yükle gibi davranabilir
-        location.reload();
-    } else {
-        // "Yerel" ürünleri sil
-        document.querySelectorAll('span').forEach(span => {
-            if (span.textContent.trim() === 'Yerel') {
-                const productCard = span.closest('div[role="group"]');
-                if (productCard) {
-                    const topContainer = productCard.parentElement?.parentElement;
-                    if (topContainer) {
-                        topContainer.remove();
-                    } else {
-                        productCard.remove();
-                    }
-                }
-            }
-        });
-    }
+  if (!enabled) {
+    location.reload();
+  } else {
+    document.querySelectorAll("span").forEach((span) => {
+      if (
+        span.textContent.trim() === "Yerel" ||
+        span.textContent.trim() === "Local"
+      ) {
+        const productCard = span.closest('div[role="group"]');
+        if (productCard) {
+          const topContainer = productCard.parentElement?.parentElement;
+          if (topContainer) {
+            topContainer.remove();
+          } else {
+            productCard.remove();
+          }
+        }
+      }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Narrow `content_scripts` match pattern from `<all_urls>` to `*://*.temu.com/*` to prevent unintended filtering on other websites
- Redesign popup UI with dark theme and animated toggle switch
- Add missing `'Local'` keyword check in popup's `toggleProducts` function (consistent with content.js)

Closes #3

## Test plan
- [ ] Load extension in Chrome and verify it only activates on temu.com
- [ ] Verify popup toggle switch works correctly (Aktif/Pasif states)
- [ ] Confirm local products are still filtered on Temu pages
- [ ] Verify no filtering occurs on non-Temu websites

🤖 Generated with [Claude Code](https://claude.com/claude-code)